### PR TITLE
fix(config): fix config creation & set subcommand

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ concurrency:
 jobs:
   test:
     strategy:
+      fail-fast: false # allow other jobs to finish if one fails
       matrix:
         go-version: [1.18.x, 1.19.x]
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -38,14 +38,14 @@ var configGetCommand = &cobra.Command{
 }
 
 var configSetCommand = &cobra.Command{
-	Use:                   "set <key>=<value>",
+	Use:                   "set <key> <value>",
 	Short:                 "Set a key from the config file",
 	Long:                  "Set a key from the config file\nFor all values, check the README at https://github.com/ismailshak/transit",
-	Example:               "  transfer config set core.location=dmv\n  transfer config set dmv.api_key=abcdef",
+	Example:               "  transfer config set core.location dmv\n  transfer config set dmv.api_key abcdef",
 	DisableFlagsInUseLine: true,
-	Args:                  cobra.ExactArgs(1),
+	Args:                  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		ExecuteSet(args[0])
+		ExecuteSet(args[0], args[1])
 	},
 }
 
@@ -84,14 +84,8 @@ func ExecuteGet(key string) {
 }
 
 // Entry point for `config set`
-func ExecuteSet(arg string) {
-	key, value, valid := parseSetArg(arg)
-	if !valid {
-		logger.Warn(fmt.Sprintf("Could not parse '%s'. Make sure it's in the format <key>=<value>\n", key))
-		return
-	}
-
-	valid = validateKey(key, value)
+func ExecuteSet(key, value string) {
+	valid := validateKey(key, value)
 	if !valid {
 		return
 	}
@@ -116,10 +110,6 @@ func parseSetArg(arg string) (string, string, bool) {
 	return parts[0], parts[1], true
 }
 
-var validLocations = map[string]bool{
-	"dmv": true,
-}
-
 func validateKey(key, value string) bool {
 	if key == "core.location" {
 		valid := validateLocation(value)
@@ -130,6 +120,10 @@ func validateKey(key, value string) bool {
 	}
 
 	return true
+}
+
+var validLocations = map[string]bool{
+	"dmv": true,
 }
 
 func validateLocation(location string) bool {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,10 +4,7 @@ Copyright © 2023 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
-	"errors"
 	"fmt"
-	"io/fs"
-	"os"
 	"strings"
 
 	"github.com/ismailshak/transit/logger"
@@ -19,7 +16,7 @@ var configCmd = &cobra.Command{
 	Use:   "config <args>",
 	Short: "Manage configuration for transit CLI",
 	Long: `
-Get and set configuration options. 
+Get and set configuration options.
 
 For nested config options, use a period/dot as a delimiter.
 
@@ -142,11 +139,4 @@ func validateLocation(location string) bool {
 
 func getConfigPath() string {
 	return vp.ConfigFileUsed()
-}
-
-func createConfigIfNotFound(configPath string) {
-	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
-		logger.Debug(fmt.Sprintf("Config not found. Creating a config file at path '%s'", configPath))
-		os.WriteFile(configPath, []byte{}, fs.FileMode(os.O_CREATE))
-	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,6 @@ func initConfig() {
 func LoadConfig(path string) {
 	configFile := config.GetConfig()
 	if path != "" {
-		logger.Debug(fmt.Sprintf("Config path override provided: '%s'", path))
 		vp.SetConfigFile(path)
 	} else {
 		homeDir, err := os.UserHomeDir()
@@ -78,7 +77,8 @@ func LoadConfig(path string) {
 			helpers.Exit(helpers.EXIT_BAD_CONFIG)
 		}
 
-		err = helpers.CreatePathIfNotFound(homeDir + "/.config/transit/config.yml")
+		fullConfigPath := homeDir + "/.config/transit/config.yml"
+		err = helpers.CreatePathIfNotFound(fullConfigPath)
 		if err != nil {
 			logger.Error(fmt.Sprintf("Failed to create config directory: %s", err))
 			helpers.Exit(helpers.EXIT_BAD_CONFIG)
@@ -100,7 +100,4 @@ func LoadConfig(path string) {
 		logger.Error("Failed to parse config" + fmt.Sprint(err))
 		helpers.Exit(helpers.EXIT_BAD_CONFIG)
 	}
-
-	// TODO: we probably don't need to do this, given its already a pointer
-	config.SetConfig(configFile)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,10 +72,21 @@ func LoadConfig(path string) {
 		logger.Debug(fmt.Sprintf("Config path override provided: '%s'", path))
 		vp.SetConfigFile(path)
 	} else {
-		createConfigIfNotFound(os.Getenv("HOME") + "/.config/transit/config.yml")
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			logger.Error(fmt.Sprint(err))
+			helpers.Exit(helpers.EXIT_BAD_CONFIG)
+		}
+
+		err = helpers.CreatePathIfNotFound(homeDir + "/.config/transit/config.yml")
+		if err != nil {
+			logger.Error(fmt.Sprintf("Failed to create config directory: %s", err))
+			helpers.Exit(helpers.EXIT_BAD_CONFIG)
+		}
+
 		vp.SetConfigName("config")
 		vp.SetConfigType("yaml")
-		vp.AddConfigPath("$HOME/.config/transit/")
+		vp.AddConfigPath(homeDir + "/.config/transit/")
 	}
 
 	err := vp.ReadInConfig()

--- a/helpers/fs.go
+++ b/helpers/fs.go
@@ -1,0 +1,65 @@
+package helpers
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ismailshak/transit/logger"
+)
+
+func FileExists(filePath string) bool {
+	_, err := os.Stat(filePath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			logger.Debug(fmt.Sprint(err))
+		}
+
+		return false
+	}
+
+	return true
+}
+
+func DirExists(dirPath string) bool {
+	info, err := os.Stat(dirPath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			logger.Debug(fmt.Sprint(err))
+		}
+
+		return false
+	}
+
+	if !info.IsDir() {
+		logger.Debug(fmt.Sprintf("Expected a directory but found a file: %s", dirPath))
+		return false
+	}
+
+	return true
+}
+
+func WriteFile(filePath string, content []byte) error {
+	return os.WriteFile(filePath, content, 0777)
+}
+
+func CreateDir(dirPath string) error {
+	return os.MkdirAll(dirPath, 0777)
+}
+
+func CreatePathIfNotFound(configPath string) error {
+	if FileExists(configPath) {
+		return nil
+	}
+
+	dirPath := filepath.Dir(configPath)
+	if !DirExists(dirPath) {
+		err := CreateDir(dirPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	return WriteFile(configPath, []byte{})
+}

--- a/helpers/fs_test.go
+++ b/helpers/fs_test.go
@@ -1,0 +1,71 @@
+package helpers_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ismailshak/transit/helpers"
+)
+
+func TestCreateIfNotFound_NotFound(t *testing.T) {
+	testFilePath := t.TempDir() + "./config/create-config.yml"
+
+	err := helpers.CreatePathIfNotFound(testFilePath)
+	if err != nil {
+		t.Logf("Failed to create path: %s", err)
+		t.FailNow()
+	}
+
+	if !helpers.FileExists(testFilePath) {
+		t.Logf("file '%s' was not created", testFilePath)
+		t.FailNow()
+	}
+
+	testContent := "Hello"
+	err = helpers.WriteFile(testFilePath, []byte(testContent))
+	if err != nil {
+		t.Logf("File created could not be written to: %s", err)
+		t.FailNow()
+	}
+
+	content, err := os.ReadFile(testFilePath)
+	if err != nil {
+		t.Logf("File created could not be read: %s", err)
+		t.FailNow()
+	}
+
+	if string(content) != testContent {
+		t.Logf("File created did not have the correct content. Expected '%s' but found '%s'", testContent, string(content))
+		t.FailNow()
+	}
+}
+
+func TestCreateIfNotFound_Found(t *testing.T) {
+	testFilePath := t.TempDir() + "./config/exists-config.yml"
+	os.MkdirAll(filepath.Dir(testFilePath), 0777)
+
+	testContent := "Already exists"
+	err := helpers.WriteFile(testFilePath, []byte(testContent))
+	if err != nil {
+		t.Logf("Failed to create test file: %s", err)
+		t.FailNow()
+	}
+
+	err = helpers.CreatePathIfNotFound(testFilePath)
+	if err != nil {
+		t.Logf("Failed to create path: %s", err)
+		t.FailNow()
+	}
+
+	content, err := os.ReadFile(testFilePath)
+	if err != nil {
+		t.Logf("File created could not be read: %s", err)
+		t.FailNow()
+	}
+
+	if string(content) != testContent {
+		t.Logf("File created did not have the correct content. Expected '%s' but found '%s'", testContent, string(content))
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
- actually create a config it didn't exist
- changed `set` syntax from `config set <key>=<value>` to `config set <key> <value>`
  - quotes should be automatically handled now (e.g. `config set "key" "value"`) but they're not required