### PR TITLE
refactor(client): dynamically pick client from location

### DIFF
--- a/api/base.go
+++ b/api/base.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/ismailshak/transit/config"
 	"github.com/ismailshak/transit/helpers"
 	"github.com/ismailshak/transit/logger"
@@ -35,4 +37,20 @@ func DmvClient() *DmvApi {
 		apiKey:  apiKey,
 		baseUrl: DMV_BASE_URL,
 	}
+}
+
+func GetClient(location string) Api {
+	if location == "" {
+		logger.Error("No location found in config at 'core.location'")
+		return nil
+	}
+
+	switch location {
+	case "dmv":
+		return DmvClient()
+	default:
+		logger.Error(fmt.Sprintf("Invalid location '%s'", location))
+	}
+
+	return nil
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -5,6 +5,8 @@ package cmd
 
 import (
 	"github.com/ismailshak/transit/api"
+	"github.com/ismailshak/transit/config"
+	"github.com/ismailshak/transit/helpers"
 	"github.com/ismailshak/transit/list"
 	"github.com/spf13/cobra"
 )
@@ -22,7 +24,12 @@ try being more specific by adding more characters.
 	`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := api.DmvClient()
+		location := config.GetConfig().Core.Location
+		client := api.GetClient(location)
+		if client == nil {
+			helpers.Exit(helpers.EXIT_BAD_CONFIG)
+		}
+
 		list.Execute(client, args)
 	},
 }


### PR DESCRIPTION
- adds a requirement for `core.location` to be set in config
- no longer defaults to `dmv`