### PR TITLE
feat(at): implement `--watch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,12 @@ transit config path
 
 <details>
 
-<summary>Full list of available config options</summary>
+<summary>Expand for full list of available config options</summary>
 
 ```yaml
 core:
   location: <string>
+  watch_interval: 10 # default
 
 dmv:
   api_key: <string>
@@ -123,6 +124,9 @@ transit at <station_name>
 
 # multiple stations
 transit at <station-1> <station-2> <station-3>
+
+# watch mode, --watch or -w (one or many stations)
+transit at <station> --watch
 
 # examples
 transit at --help

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,9 @@ func LoadConfig(path string) {
 		vp.AddConfigPath(homeDir + "/.config/transit/")
 	}
 
+	// config defaults
+	vp.SetDefault("core.watch_interval", 10)
+
 	err := vp.ReadInConfig()
 	if err != nil {
 		logger.Error(fmt.Sprint(err))
@@ -94,7 +97,7 @@ func LoadConfig(path string) {
 
 	err = vp.Unmarshal(&configFile)
 	if err != nil {
-		logger.Error("Failed to parse config" + fmt.Sprint(err))
+		logger.Error("Failed to parse config\n" + fmt.Sprint(err))
 		helpers.Exit(helpers.EXIT_BAD_CONFIG)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -5,8 +5,9 @@ type DmvConfig struct {
 }
 
 type CoreConfig struct {
-	Verbose  bool
-	Location string `mapstructure:"location"`
+	Verbose       bool
+	Location      string `mapstructure:"location"`
+	WatchInterval int    `mapstructure:"watch_interval"`
 }
 
 type Config struct {

--- a/helpers/lines.go
+++ b/helpers/lines.go
@@ -24,5 +24,5 @@ func GetColorFromLine(line string) (string, string) {
 
 // If a train isn't for passengers
 func IsGhostTrain(line, destination string) bool {
-	return line == "--" || destination == "No Passenger"
+	return line == "--" || destination == "No Passenger" || line == "No"
 }

--- a/tui/buffer.go
+++ b/tui/buffer.go
@@ -1,0 +1,36 @@
+package tui
+
+import (
+	"github.com/ismailshak/transit/logger"
+)
+
+// An alternate buffer drawn on top of active terminal screen
+type Buffer struct {
+	alternateBufferEnabled bool
+	alternateBufferActive  bool
+}
+
+func NewBuffer() *Buffer {
+	return &Buffer{}
+}
+
+func (b *Buffer) StartAlternateBuffer() {
+	if !b.alternateBufferActive {
+		logger.Print("\x1b[?1049h")
+		b.alternateBufferActive = true
+	}
+}
+
+func (b *Buffer) StopAlternateBuffer() {
+	if b.alternateBufferActive {
+		logger.Print("\x1b[?1049l")
+		b.alternateBufferActive = false
+	}
+}
+
+func (b *Buffer) RefreshScreen() {
+	// Move cursor to 0,0
+	logger.Print("\x1b[0;0H")
+	// Clear from cursor to bottom of screen
+	logger.Print("\x1b[J")
+}

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -1,0 +1,7 @@
+package tui
+
+import "github.com/charmbracelet/lipgloss"
+
+func Bold(text string) string {
+	return lipgloss.NewStyle().Bold(true).Render(text)
+}


### PR DESCRIPTION
- adds `--watch` to `at` command
- utilizes alternate buffer screen
  - easy way to take over entire terminal window
  - once exits, the user's previous terminal session and history is restored

TODO for later: fetch all stations at once (for multiple args), instead of fetch per station...